### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,8 +48,7 @@ Imports:
     abind,
     RNifti (>= 0.9.0),
     rticles
-Enhances: dcemriS4,
-    fmri,
+Enhances: fmri,
     oro.dicom
 License: BSD_3_clause + file LICENSE
 BugReports: https://github.com/bjw34032/oro.nifti/issues


### PR DESCRIPTION
Thanks, we see:

   Suggests or Enhances not in mainstream repositories:
     dcemriS4

I do not see (neither via Additonal_repositories nor in the Description
field) where you declare where to get the package from?

   Size of tarball: 5224789 bytes

Not more than 5 MB for a CRAN package, please.
